### PR TITLE
#34 注文キャンセル

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -11,8 +11,8 @@ class OrdersController < ApplicationController
     @order = current_user.orders.find_by(id: params[:id])
     if @order.find_preparation_shipment_status
       @order.destroy!
-      redirect_to orders_path
     end
+    redirect_to orders_path
   end
 
   def index

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,6 +5,7 @@ class OrdersController < ApplicationController
 
   def destroy
     @order = Order.find_by(id: params[:id]).destroy!
+    #TODO: 注文履歴ページが実装されたら以下の遷移先を変更すること
     redirect_to order_path
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,10 +9,9 @@ class OrdersController < ApplicationController
 
   def destroy
     @order = Order.find_by(id: params[:id]).destroy!
-    #TODO: 注文履歴ページが実装されたら以下の遷移先を変更すること
-    redirect_to order_path
+    redirect_to orders_path
   end
-  
+
   def index
     @orders = current_user.orders.page(params[:page]).per(10)
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,8 +8,11 @@ class OrdersController < ApplicationController
   end
 
   def destroy
-    @order = Order.find_by(id: params[:id]).destroy!
-    redirect_to orders_path
+    @order = current_user.orders.find_by(id: params[:id])
+    if @order.find_preparation_shipment_status
+      @order.destroy!
+      redirect_to orders_path
+    end
   end
 
   def index

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,4 +2,9 @@ class OrdersController < ApplicationController
   def show
     @order = Order.find_by(id: params[:id])
   end
+
+  def destroy
+    @order = Order.find_by(id: params[:id]).destroy!
+    redirect_to order_path
+  end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -16,7 +16,7 @@
         </div>
         <div class="text-end">
         <% if @order.find_preparation_shipment_status %>
-          <%= link_to "注文をキャンセルする", @order, method: :delete, class: "btn btn-danger" %>
+          <%= link_to "注文をキャンセルする", @order, method: :delete, class: "btn btn-danger", data: {confirm: "本当にキャンセルしますか？"} %>
         <% end %>
         </div>
         <table class="table table-borderless mt-3">

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -15,7 +15,9 @@
           <%= @order.find_preparation_shipment_status ? "注文状態：準備中" : "注文状態：発送済" %>
         </div>
         <div class="text-end">
+        <% if @order.find_preparation_shipment_status %>
           <%= link_to "注文をキャンセルする", @order, method: :delete, class: "btn btn-danger" %>
+        <% end %>
         </div>
         <table class="table table-borderless mt-3">
           <thead>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -15,7 +15,7 @@
           <%= @order.find_preparation_shipment_status ? "注文状態：準備中" : "注文状態：発送済" %>
         </div>
         <div class="text-end">
-          <button type="button" class="btn btn-danger">注文をキャンセルする</button>
+          <%= link_to "注文をキャンセルする", @order, method: :delete, class: "btn btn-danger" %>
         </div>
         <table class="table table-borderless mt-3">
           <thead>


### PR DESCRIPTION
## このプルリクエストで何をしたのか

- app/controllers/orders_controller.rb destroyアクション設定
- app/views/orders/show.html.erb 準備中があればキャンセルボタンを表示する設定を追加

## 対象issue
https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/34

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

注文キャンセル実行後の遷移先は、本来は注文履歴だが未実装のため仮で注文詳細画面に設定。


## チェックリスト
- [x] 動作確認は実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
