### PR TITLE
#30 ヘッダー修正

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,7 +10,7 @@
             <p><%= @current_user.last_name %> <%= @current_user.first_name %>さん</p>
           </ul>
           <ul class="navbar-nav">
-            <a class="nav-link text-dark" href="#">商品検索</a>
+            <%= link_to '商品検索', products_path, class: "nav-link text-dark" %>
             <a class="nav-link text-dark" href="#">カート</a>
             <a class="nav-link text-dark" href="#">注文履歴</a>
             <a class="nav-link text-dark" href="#">ユーザ情報</a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
           <ul class="navbar-nav">
             <%= link_to '商品検索', products_path, class: "nav-link text-dark" %>
             <a class="nav-link text-dark" href="#">カート</a>
-            <a class="nav-link text-dark" href="#">注文履歴</a>
+            <%= link_to '注文履歴', orders_path, class: "nav-link text-dark" %>
             <%= link_to 'ユーザ情報', user_path(@current_user), class: "nav-link text-dark" %>
             <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-dark" %>
           </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,11 +1,11 @@
 <header>
-  <% if logged_in? %>
-    <nav class="navbar navbar-expand-lg navbar-light">
-      <div class="container-fluid">
-        <div class="navbar-nav mr-auto">
-          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
-        </div>
-        <div>
+  <nav class="navbar navbar-expand-lg navbar-light">
+    <div class="container-fluid">
+      <div class="navbar-nav mr-auto">
+        <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
+      </div>
+      <div>
+        <% if logged_in? %>
           <ul>
             <p><%= @current_user.last_name %> <%= @current_user.first_name %>さん</p>
           </ul>
@@ -16,24 +16,15 @@
             <a class="nav-link text-dark" href="#">ユーザ情報</a>
             <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-dark" %>
           </ul>
-        </div>
-      </div>
-    </nav>
-  <% else %>
-    <nav class="navbar navbar-expand-lg navbar-light">
-      <div class="container-fluid">
-        <div class="navbar-nav mr-auto">
-          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
-        </div>
-        <div>
+        <% else %>
           <ul>
             <li>
               <a class="text-dark" href="#"> ログイン </a>
               <a class="text-dark" href="#"> 新規登録 </a>
             </li>
           </ul>
-        </div>
+        <% end %>
       </div>
-    </nav>
-  <% end %>
+    </div>
+  </nav>
 </header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,21 +1,39 @@
 <header>
-  <nav class="navbar navbar-expand-lg navbar-light">
-    <div class="container-fluid">
-      <div class="navbar-nav mr-auto">
-        <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
+  <% if logged_in? %>
+    <nav class="navbar navbar-expand-lg navbar-light">
+      <div class="container-fluid">
+        <div class="navbar-nav mr-auto">
+          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
+        </div>
+        <div>
+          <ul>
+            <p><%= @current_user.last_name %> <%= @current_user.first_name %>さん</p>
+          </ul>
+          <ul class="navbar-nav">
+            <a class="nav-link text-dark" href="#">商品検索</a>
+            <a class="nav-link text-dark" href="#">カート</a>
+            <a class="nav-link text-dark" href="#">注文履歴</a>
+            <a class="nav-link text-dark" href="#">ユーザ情報</a>
+            <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-dark" %>
+          </ul>
+        </div>
       </div>
-      <div>
-        <ul>
-          <p>〇〇 ××さん</p>
-        </ul>
-        <ul class="navbar-nav">
-          <a class="nav-link text-dark" href="#">商品検索</a>
-          <a class="nav-link text-dark" href="#">カート</a>
-          <a class="nav-link text-dark" href="#">注文履歴</a>
-          <a class="nav-link text-dark" href="#">ユーザ情報</a>
-          <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-dark" %>
-        </ul>
+    </nav>
+  <% else %>
+    <nav class="navbar navbar-expand-lg navbar-light">
+      <div class="container-fluid">
+        <div class="navbar-nav mr-auto">
+          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
+        </div>
+        <div>
+          <ul>
+            <li>
+              <a class="text-dark" href="#"> ログイン </a>
+              <a class="text-dark" href="#"> 新規登録 </a>
+            </li>
+          </ul>
+        </div>
       </div>
-    </div>
-  </nav>
+    </nav>
+  <% end %>
 </header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,6 +20,7 @@
           <ul>
             <li>
               <%= link_to 'ログイン', login_path, class: "text-dark" %>
+              <%# TODO: 新規登録画面が実装されたらsignup_pathに遷移させる%>
               <a class="text-dark" href="#"> 新規登録 </a>
             </li>
           </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,13 +13,13 @@
             <%= link_to '商品検索', products_path, class: "nav-link text-dark" %>
             <a class="nav-link text-dark" href="#">カート</a>
             <a class="nav-link text-dark" href="#">注文履歴</a>
-            <a class="nav-link text-dark" href="#">ユーザ情報</a>
+            <%= link_to 'ユーザ情報', user_path(@current_user), class: "nav-link text-dark" %>
             <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-dark" %>
           </ul>
         <% else %>
           <ul>
             <li>
-              <a class="text-dark" href="#"> ログイン </a>
+              <%= link_to 'ログイン', login_path, class: "text-dark" %>
               <a class="text-dark" href="#"> 新規登録 </a>
             </li>
           </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -57,7 +57,7 @@
       </section>
 
       <div class="text-center">
-        <a class="btn btn-primary" href="#" role="button">修正/退会する</a>
+        <%= link_to '修正/退会する', edit_user_path, class: "btn btn-primary" %>
       </div>
 
     </main>


### PR DESCRIPTION
## このプルリクエストで何をしたのか

#27ページ遷移のissueの対応はこのPRで一緒に行い、ページ遷移のプルリクはクローズする。

1. 以下の画面遷移機能を実装

- ヘッダーの商品検索をクリック→商品検索ページ
- ユーザー詳細ページの「修正/退会」ボタン→ユーザー修正ページ

2. ログイン時、ログアウト時で表示する切り替え
3. ログイン時にヘッダーに名前を表示

## 対象issue
https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/30

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
- [ ] 動作確認は実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
