### PR TITLE
#21 エラーメッセージの日本語化

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find_by(id: params[:id])
-    if @user.update!(user_params)
+    if @user.update(user_params)
       flash[:success] = '更新に成功しました'
       redirect_to @user
     else

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Myapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/models/category.yml
+++ b/config/locales/models/category.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    models:
+      category: カテゴリー
+    attributes:
+      category:
+        category_name: カテゴリー名

--- a/config/locales/models/order.yml
+++ b/config/locales/models/order.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    models:
+      order: 注文
+    attributes:
+      order:
+        order_date: 注文日
+        order_number: 注文番号

--- a/config/locales/models/order_detail.yml
+++ b/config/locales/models/order_detail.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    models:
+      order_detail: 注文詳細
+    attributes:
+      order_detail:
+        order_detail_number: 注文番号
+        order_quantity: 注文個数
+        shipment_date: 発送日

--- a/config/locales/models/product.yml
+++ b/config/locales/models/product.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    models:
+      product: 商品
+    attributes:
+      product:
+        product_name: 商品名
+        price: 販売単価
+        regist_date: 商品登録日

--- a/config/locales/models/product_status.yml
+++ b/config/locales/models/product_status.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    models:
+      product_status: 商品状態
+    attributes:
+      product_status:
+        product_status_name: 商品状態名

--- a/config/locales/models/purchase.yml
+++ b/config/locales/models/purchase.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      purchase: 仕入
+    attributes:
+      purchase:
+        purchase_price: 仕入価格
+        purchase_quantity: 仕入個数
+        purchase_company: 仕入先会社
+        order_date: 発注日
+        purchase_date: 納入日

--- a/config/locales/models/sale_status.yml
+++ b/config/locales/models/sale_status.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    models:
+      sale_status: 販売状態
+    attributes:
+      sale_status:
+        sale_status_name: 販売状態名

--- a/config/locales/models/shipment_status.yml
+++ b/config/locales/models/shipment_status.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    models:
+      shipment_status: 発送状態
+    attributes:
+      shipment_status:
+        shipment_status_name: 発送状態名

--- a/config/locales/models/user.yml
+++ b/config/locales/models/user.yml
@@ -1,0 +1,17 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        last_name: 姓
+        first_name: 名
+        password: パスワード
+        zipcode: 住所
+        prefecture: 都道府県
+        municipality: 市区町村
+        address: 住所
+        apartments: 建物名
+        email: Eメール
+        phone_number: 電話番号
+        company_name: 会社名

--- a/config/locales/models/user.yml
+++ b/config/locales/models/user.yml
@@ -7,6 +7,7 @@ ja:
         last_name: 姓
         first_name: 名
         password: パスワード
+        password_confirmation: パスワード(再入力)
         zipcode: 住所
         prefecture: 都道府県
         municipality: 市区町村

--- a/config/locales/models/user_classification.yml
+++ b/config/locales/models/user_classification.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    models:
+      user_classification: ユーザー種別
+    attributes:
+      user_classification:
+        user_classification_name: ユーザ種別名


### PR DESCRIPTION
## このプルリクエストで何をしたのか

- エラーメッセージの日本語化

1. config/locales配下にmodelsフォルダ新規作成
2. config/locales/models配下にモデルごとのymlファイルを作成
3. config/application.rbに、`config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]` を追記 → config/locales以下のディレクトリ内にある全てのymlファイルを読み込む
4. ユーザー情報修正時にエラー画面ではなくflashメッセージが出るようにapp/controllers/users_controller.rbのupdate箇所を修正

## 対象issue
https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/21

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
- [x] 動作確認は実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
