### PR TITLE
#29 ユーザ登録ページ、登録処理

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
+    @user.user_classification_id = 1
     if @user.save
       flash[:success] = 'ユーザーを登録しました。こちらからログインしてください。'
       redirect_to login_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,16 +38,17 @@ class UsersController < ApplicationController
     end
   end
 
-  def user_params
-    params.require(:user).permit(:last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments, :email, :phone_number, :company_name, :password, :password_confirmation)
-  end
-
-  def correct_user
-    user = User.find_by(id: params[:id])
-    if current_user != user
-      flash[:danger] = '他人の情報にアクセスすることはできません。'
-      redirect_to root_path
+  private
+  
+    def user_params
+      params.require(:user).permit(:last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments, :email, :phone_number, :company_name, :password, :password_confirmation)
     end
-  end
 
+    def correct_user
+      user = User.find_by(id: params[:id])
+      if current_user != user
+        flash[:danger] = '他人の情報にアクセスすることはできません。'
+        redirect_to root_path
+      end
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-      params.require(:user).permit(:last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments, :email, :phone_number, :company_name, :password, :password_confirmation)
+    params.require(:user).permit(:last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments, :email, :phone_number, :company_name, :password, :password_confirmation)
   end
 
   def correct_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,21 @@ class UsersController < ApplicationController
     @user = User.find_by(id: params[:id])
   end
 
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      flash[:success] = 'ユーザーを登録しました。こちらからログインしてください。'
+      redirect_to login_path
+    else
+      flash.now[:danger] = '登録に失敗しました'
+      render "new"
+    end
+  end
+
   def update
     @user = User.find_by(id: params[:id])
     if @user.update!(user_params)

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -24,6 +24,6 @@
     <% end %>
 
     <div class="d-flex justify-content-center">
-      <a href="">まだ登録がお済みでない方はこちら</a>
+      <%= link_to 'まだ登録がお済みでない方はこちら', signup_path %>
     </div>
   </main>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,23 +1,4 @@
 <% provide(:title, "ログイン画面") %>
-  <%# TODO: ログイン機能を実装したときにヘッダー部分をテンプレート化する%>
-  <header>
-    <nav class="navbar navbar-expand-lg navbar-light">
-      <div class="container-fluid">
-        <div class="navbar-nav mr-auto">
-          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
-        </div>
-        <div>
-          <ul>
-            <li>
-              <a class="text-dark" href="#"> ログイン </a>
-              <a class="text-dark" href="#"> 新規登録 </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-  </header>
-
   <main>
     <h4 class="d-flex justify-content-center mt-5 mb-3">ログイン画面</h4>
     <%= form_with scope: :session, url: login_path, local: true do |f| %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,96 @@
+<% provide(:title, "ユーザー登録") %>
+
+<div class="container">
+	<div class="jumbotron text-center bg-white mt-5">
+		<h2>お客様情報登録</h2>
+	</div>
+	<div class="row mb-5 ml-5">
+		<div class="col-sm-6 offset-sm-3">
+		  <%= form_with(model: @user, local: true, url: signup_path) do |f| %>
+			  <div>
+				  <p>氏名</p>
+				  <div class="row ms-2">
+					  <%= f.label :last_name, "姓", class: "col-sm" %>
+					  <div class="col-sm-5">
+						  <%= f.text_field :last_name, class:'form-control' %>
+					  </div>
+					  <%= f.label :last_name, "名", class: "col-sm" %>
+					  <div class="col-sm-5">
+						  <%= f.text_field :first_name, class:'form-control' %>
+					  </div>
+				  </div>
+				  <div>
+					  <%= f.label :zipcode, "郵便番号" %>
+					  <div class="col-sm-6 ms-4">
+							  <%= f.text_field :zipcode, class:'form-control' %>
+					  </div>
+				  </div>
+				  <div>
+					  <p class="mb-1">住所</p>
+					  <div class="ms-4">
+						  <div class="row">
+							  <%= f.label :prefecture, "都道府県", class: "mt-2 ml-4 col-sm" %>
+							  <div class="col-sm-9 mt-1">
+								  <%= f.text_field :prefecture, class:'form-control' %>
+							  </div>
+						  </div>
+
+						  <div class="row">
+							  <%= f.label :municipality, "市区町村", class: "mt-2 ml-4 col-sm" %>
+							  <div class="col-sm-9 mt-1">
+								  <%= f.text_field :municipality, class:'form-control' %>
+							  </div>
+						  </div>
+						  <div class="row">
+							  <%= f.label :address, "番地", class: "mt-2 ml-4 col-sm" %>
+							  <div class="col-sm-9 ml-4 mt-1">
+								  <%= f.text_field :address, class:'form-control' %>
+							  </div>
+						  </div>
+					  </div>
+				  </div>
+				  <div>
+						  <%= f.label :apartments, "マンション・部屋番号", class: "ml-2 ms-4" %>
+					  <div class="offset-sm-1">
+						  <div class="ml-5 mr-5">
+							  <%= f.text_field :apartments, class:'form-control' %>
+						  </div>
+					  </div>
+				  </div>
+			  </div>
+			  <div>
+				  <%= f.label :email, "メールアドレス" %>
+				  <div class="ml-3 mr-5 ms-4">
+					  <%= f.text_field :email, class:'form-control' %>
+				  </div>
+			  </div>
+			  <div>
+					  <%= f.label :phone_number, "電話番号" %>
+				  <div class="ml-3 mr-5 ms-4">
+					  <%= f.text_field :phone_number, class:'form-control' %>
+				  </div>
+			  </div>
+			  <div>
+				  <%= f.label :password, "パスワード" %>
+				  <div class="col-sm-8 ms-4">
+					  <%= f.password_field :password, class:'form-control' %>
+				  </div>
+			  </div>
+			  <div>
+				  <%= f.label :password_confirmation, "パスワード再入力" %>
+				  <div class="col-sm-8 ms-4">
+					  <%= f.password_field :password_confirmation, class:'form-control' %>
+				  </div>
+			  </div>
+			  <div class="row justify-content-center">
+				  <div class="col-sm-2 mt-5">
+					  <%= f.submit "登録", class: "btn btn-primary btn-block" %>
+				  </div>
+			  </div>
+		  <% end %>
+			<div class="mt-5 text-center">
+				<h3><%= link_to 'ログインはこちらから', login_path %></h3>
+			</div>
+		</div>
+	</div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,96 +1,96 @@
 <% provide(:title, "ユーザー登録") %>
 
 <div class="container">
-	<div class="jumbotron text-center bg-white mt-5">
-		<h2>お客様情報登録</h2>
-	</div>
-	<div class="row mb-5 ml-5">
-		<div class="col-sm-6 offset-sm-3">
-		  <%= form_with(model: @user, local: true, url: signup_path) do |f| %>
-			  <div>
-				  <p>氏名</p>
-				  <div class="row ms-2">
-					  <%= f.label :last_name, "姓", class: "col-sm" %>
-					  <div class="col-sm-5">
-						  <%= f.text_field :last_name, class:'form-control' %>
-					  </div>
-					  <%= f.label :last_name, "名", class: "col-sm" %>
-					  <div class="col-sm-5">
-						  <%= f.text_field :first_name, class:'form-control' %>
-					  </div>
-				  </div>
-				  <div>
-					  <%= f.label :zipcode, "郵便番号" %>
-					  <div class="col-sm-6 ms-4">
-							  <%= f.text_field :zipcode, class:'form-control' %>
-					  </div>
-				  </div>
-				  <div>
-					  <p class="mb-1">住所</p>
-					  <div class="ms-4">
-						  <div class="row">
-							  <%= f.label :prefecture, "都道府県", class: "mt-2 ml-4 col-sm" %>
-							  <div class="col-sm-9 mt-1">
-								  <%= f.text_field :prefecture, class:'form-control' %>
-							  </div>
-						  </div>
+  <div class="jumbotron text-center bg-white mt-5">
+    <h2>お客様情報登録</h2>
+  </div>
+  <div class="row mb-5 ml-5">
+    <div class="col-sm-6 offset-sm-3">
+      <%= form_with(model: @user, local: true, url: signup_path) do |f| %>
+        <div>
+          <p>氏名</p>
+          <div class="row ms-2">
+            <%= f.label :last_name, "姓", class: "col-sm" %>
+            <div class="col-sm-5">
+              <%= f.text_field :last_name, class:'form-control' %>
+            </div>
+            <%= f.label :last_name, "名", class: "col-sm" %>
+            <div class="col-sm-5">
+              <%= f.text_field :first_name, class:'form-control' %>
+            </div>
+          </div>
+          <div>
+            <%= f.label :zipcode, "郵便番号" %>
+            <div class="col-sm-6 ms-4">
+              <%= f.text_field :zipcode, class:'form-control' %>
+            </div>
+          </div>
+          <div>
+            <p class="mb-1">住所</p>
+            <div class="ms-4">
+              <div class="row">
+                <%= f.label :prefecture, "都道府県", class: "mt-2 ml-4 col-sm" %>
+                <div class="col-sm-9 mt-1">
+                  <%= f.text_field :prefecture, class:'form-control' %>
+                </div>
+              </div>
 
-						  <div class="row">
-							  <%= f.label :municipality, "市区町村", class: "mt-2 ml-4 col-sm" %>
-							  <div class="col-sm-9 mt-1">
-								  <%= f.text_field :municipality, class:'form-control' %>
-							  </div>
-						  </div>
-						  <div class="row">
-							  <%= f.label :address, "番地", class: "mt-2 ml-4 col-sm" %>
-							  <div class="col-sm-9 ml-4 mt-1">
-								  <%= f.text_field :address, class:'form-control' %>
-							  </div>
-						  </div>
-					  </div>
-				  </div>
-				  <div>
-						  <%= f.label :apartments, "マンション・部屋番号", class: "ml-2 ms-4" %>
-					  <div class="offset-sm-1">
-						  <div class="ml-5 mr-5">
-							  <%= f.text_field :apartments, class:'form-control' %>
-						  </div>
-					  </div>
-				  </div>
-			  </div>
-			  <div>
-				  <%= f.label :email, "メールアドレス" %>
-				  <div class="ml-3 mr-5 ms-4">
-					  <%= f.text_field :email, class:'form-control' %>
-				  </div>
-			  </div>
-			  <div>
-					  <%= f.label :phone_number, "電話番号" %>
-				  <div class="ml-3 mr-5 ms-4">
-					  <%= f.text_field :phone_number, class:'form-control' %>
-				  </div>
-			  </div>
-			  <div>
-				  <%= f.label :password, "パスワード" %>
-				  <div class="col-sm-8 ms-4">
-					  <%= f.password_field :password, class:'form-control' %>
-				  </div>
-			  </div>
-			  <div>
-				  <%= f.label :password_confirmation, "パスワード再入力" %>
-				  <div class="col-sm-8 ms-4">
-					  <%= f.password_field :password_confirmation, class:'form-control' %>
-				  </div>
-			  </div>
-			  <div class="row justify-content-center">
-				  <div class="col-sm-2 mt-5">
-					  <%= f.submit "登録", class: "btn btn-primary btn-block" %>
-				  </div>
-			  </div>
-		  <% end %>
-			<div class="mt-5 text-center">
-				<h3><%= link_to 'ログインはこちらから', login_path %></h3>
-			</div>
-		</div>
-	</div>
+              <div class="row">
+                <%= f.label :municipality, "市区町村", class: "mt-2 ml-4 col-sm" %>
+                <div class="col-sm-9 mt-1">
+                  <%= f.text_field :municipality, class:'form-control' %>
+                </div>
+              </div>
+              <div class="row">
+                <%= f.label :address, "番地", class: "mt-2 ml-4 col-sm" %>
+                <div class="col-sm-9 ml-4 mt-1">
+                  <%= f.text_field :address, class:'form-control' %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <%= f.label :apartments, "マンション・部屋番号", class: "ml-2 ms-4" %>
+            <div class="offset-sm-1">
+              <div class="ml-5 mr-5">
+                <%= f.text_field :apartments, class:'form-control' %>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <%= f.label :email, "メールアドレス" %>
+          <div class="ml-3 mr-5 ms-4">
+            <%= f.text_field :email, class:'form-control' %>
+          </div>
+        </div>
+        <div>
+            <%= f.label :phone_number, "電話番号" %>
+          <div class="ml-3 mr-5 ms-4">
+            <%= f.text_field :phone_number, class:'form-control' %>
+          </div>
+        </div>
+        <div>
+          <%= f.label :password, "パスワード" %>
+          <div class="col-sm-8 ms-4">
+            <%= f.password_field :password, class:'form-control' %>
+          </div>
+        </div>
+        <div>
+          <%= f.label :password_confirmation, "パスワード再入力" %>
+          <div class="col-sm-8 ms-4">
+            <%= f.password_field :password_confirmation, class:'form-control' %>
+          </div>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-sm-2 mt-5">
+            <%= f.submit "登録", class: "btn btn-primary btn-block" %>
+          </div>
+        </div>
+      <% end %>
+      <div class="mt-5 text-center">
+        <h3><%= link_to 'ログインはこちらから', login_path %></h3>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -65,7 +65,7 @@
           </div>
         </div>
         <div>
-            <%= f.label :phone_number, "電話番号" %>
+          <%= f.label :phone_number, "電話番号" %>
           <div class="ml-3 mr-5 ms-4">
             <%= f.text_field :phone_number, class:'form-control' %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   resources :users
   resources :products
   resources :orders
+  get '/signup', to: 'users#new'
+  post '/signup', to: 'users#create'
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'


### PR DESCRIPTION
## このプルリクエストで何をしたのか

登録ページ

- ルーティング設定 path: GET /signup
- usesコントローラーに、newアクションを追加
- new.html.erb作成　参考モックアップ: users_new.html

登録処理

- ルーティング設定　path: POST /signup
- usersコントローラにcreateアクション設定　
- ※登録後のリダイレクト先については画面定義書参照

## 対象issue

https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/29

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
- [x] 動作確認は実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
