### PR TITLE
#31 ユーザー退会処理

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:show, :edit, :update]
-  before_action :correct_user, only: [:show, :edit, :update]
+  before_action :logged_in_user, only: [:show, :edit, :update, :destroy]
+  before_action :correct_user, only: [:show, :edit, :update, :destroy]
   include SessionsHelper
   
   def show
@@ -20,6 +20,12 @@ class UsersController < ApplicationController
       flash.now[:danger] = '更新に失敗しました'
       render "edit"
     end
+  end
+
+  def destroy
+    @user = User.find_by(id: params[:id])
+    @user.destroy!
+    redirect_to root_path
   end
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,8 +23,7 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    @user = User.find_by(id: params[:id])
-    @user.destroy!
+    User.find_by(id: params[:id]).destroy!
     redirect_to root_path
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ApplicationController
 
   def destroy
     User.find_by(id: params[:id]).destroy!
+    flash[:success] = 'ユーザーを削除しました。'
     redirect_to root_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
 
   belongs_to :user_classification
   has_many :orders, dependent: :destroy
+  has_many :products, dependent: :destroy
 
   validates :last_name, presence: true, length: { maximum: 10 }
   validates :first_name, presence: true, length: { maximum: 10 }

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -108,7 +108,7 @@
             </div>
         
             <div class="col-5 offset-2">
-              <button class="btn btn-danger" type="submit">退会</button>
+              <%= link_to "退会", @user, method: :delete, data: { confirm: "ユーザーデータが全て削除されます。本当に退会しますか？" }, class: "btn btn-danger" %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
## このプルリクエストで何をしたのか

ユーザー退会処理を実装

- app/controllers/users_controller.rbにdestroyメソッド追加
- app/views/users/edit.html.erbに退会ボタンのリンクを設定

エラー対応
app/models/user.rbにproductsの外部キー制約の設定追加

## 対象issue
https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/31


## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
- [x] 動作確認は実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
